### PR TITLE
PDFBOX-4373: Add additional unit tests

### DIFF
--- a/pdfbox/src/test/java/org/apache/pdfbox/cos/COSObjectKeyTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/cos/COSObjectKeyTest.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.cos;
+
+import org.apache.pdfbox.cos.COSObjectKey;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class COSObjectKeyTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void compareToInputNotNullOutputZero() {
+
+        // Arrange
+        final COSObjectKey objectUnderTest = new COSObjectKey(0L, 0);
+        final COSObjectKey other = new COSObjectKey(0L, 0);
+
+        // Act
+        final int retval = objectUnderTest.compareTo(other);
+
+        // Assert result
+        Assert.assertEquals(0, retval);
+    }
+
+    @Test
+    public void compareToInputNotNullOutputPositive() {
+
+        // Arrange
+        final COSObjectKey objectUnderTest = new COSObjectKey(0L, 0);
+        final COSObjectKey other = new COSObjectKey(-9_223_372_036_854_775_808L, 0);
+
+        // Act
+        final int retval = objectUnderTest.compareTo(other);
+
+        // Assert result
+        Assert.assertEquals(1, retval);
+    }
+}

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdfwriter/COSWriterXRefEntryTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdfwriter/COSWriterXRefEntryTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.pdfwriter;
+
+import org.apache.pdfbox.pdfwriter.COSWriterXRefEntry;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class COSWriterXRefEntryTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void compareToInputNullOutputNegative() {
+
+        // Arrange
+        final COSWriterXRefEntry objectUnderTest = new COSWriterXRefEntry(0L, null, null);
+        final COSWriterXRefEntry obj = null;
+
+        // Act
+        final int retval = objectUnderTest.compareTo(obj);
+
+        // Assert result
+        Assert.assertEquals(-1, retval);
+    }
+}

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/PageLayoutTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/PageLayoutTest.java
@@ -19,14 +19,14 @@ import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 import static org.junit.Assert.assertEquals;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 
-/**
- * @author Tilman Hausherr
- */
 public class PageLayoutTest
 {
     /**
+     * @author Tilman Hausherr
      * Test for completeness (PDFBOX-3362).
      */
     @Test
@@ -42,5 +42,22 @@ public class PageLayoutTest
         }
         assertEquals(PageLayout.values().length, pageLayoutSet.size());
         assertEquals(PageLayout.values().length, stringSet.size());
+    }
+
+    /**
+     * @author John Bergqvist
+     */
+    @Rule public ExpectedException thrown = ExpectedException.none();
+    @Test
+    public void fromStringInputNotNullOutputIllegalArgumentException() {
+
+        // Arrange
+        final String value = "SinglePag";
+
+        // Act
+        thrown.expect(IllegalArgumentException.class);
+        PageLayout.fromString(value);
+
+        // Method is not expected to return due to exception thrown
     }
 }

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/PageModeTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/PageModeTest.java
@@ -1,0 +1,146 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.pdmodel;
+
+import org.apache.pdfbox.pdmodel.PageMode;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
+
+public class PageModeTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull() {
+
+        // Arrange
+        final String value = "FullScreen";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.FULL_SCREEN, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull2() {
+
+        // Arrange
+        final String value = "UseThumbs";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.USE_THUMBS, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull3() {
+
+        // Arrange
+        final String value = "UseOC";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.USE_OPTIONAL_CONTENT, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull4() {
+
+        // Arrange
+        final String value = "UseNone";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.USE_NONE, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull5() {
+
+        // Arrange
+        final String value = "UseAttachments";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.USE_ATTACHMENTS, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull6() {
+
+        // Arrange
+        final String value = "UseOutlines";
+
+        // Act
+        final PageMode retval = PageMode.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(PageMode.USE_OUTLINES, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputIllegalArgumentException() {
+
+        // Arrange
+        final String value = "";
+
+        // Act
+        thrown.expect(IllegalArgumentException.class);
+        PageMode.fromString(value);
+
+        // Method is not expected to return due to exception thrown
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputIllegalArgumentException2() {
+
+        // Arrange
+        final String value = "Dulacb`ecj";
+
+        // Act
+        thrown.expect(IllegalArgumentException.class);
+        PageMode.fromString(value);
+
+        // Method is not expected to return due to exception thrown
+    }
+
+    @Test
+    public void stringValueOutputNotNull() {
+
+        // Arrange
+        final PageMode objectUnderTest = PageMode.USE_OPTIONAL_CONTENT;
+
+        // Act
+        final String retval = objectUnderTest.stringValue();
+
+        // Assert result
+        Assert.assertEquals("UseOC", retval);
+    }
+}

--- a/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/state/RenderingIntentTest.java
+++ b/pdfbox/src/test/java/org/apache/pdfbox/pdmodel/graphics/state/RenderingIntentTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.pdfbox.pdmodel.graphics.state;
+
+import org.apache.pdfbox.pdmodel.graphics.state.RenderingIntent;
+import org.junit.Assert;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.ExpectedException;
+
+public class RenderingIntentTest {
+
+    @Rule public ExpectedException thrown = ExpectedException.none();
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull() {
+
+        // Arrange
+        final String value = "AbsoluteColorimetric";
+
+        // Act
+        final RenderingIntent retval = RenderingIntent.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(RenderingIntent.ABSOLUTE_COLORIMETRIC, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull2() {
+
+        // Arrange
+        final String value = "RelativeColorimetric";
+
+        // Act
+        final RenderingIntent retval = RenderingIntent.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(RenderingIntent.RELATIVE_COLORIMETRIC, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull3() {
+
+        // Arrange
+        final String value = "Perceptual";
+
+        // Act
+        final RenderingIntent retval = RenderingIntent.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(RenderingIntent.PERCEPTUAL, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull4() {
+
+        // Arrange
+        final String value = "Saturation";
+
+        // Act
+        final RenderingIntent retval = RenderingIntent.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(RenderingIntent.SATURATION, retval);
+    }
+
+    @Test
+    public void fromStringInputNotNullOutputNotNull5() {
+
+        // Arrange
+        final String value = "";
+
+        // Act
+        final RenderingIntent retval = RenderingIntent.fromString(value);
+
+        // Assert result
+        Assert.assertEquals(RenderingIntent.RELATIVE_COLORIMETRIC, retval);
+    }
+
+    @Test
+    public void stringValueOutputNotNull() {
+
+        // Arrange
+        final RenderingIntent objectUnderTest = RenderingIntent.ABSOLUTE_COLORIMETRIC;
+
+        // Act
+        final String retval = objectUnderTest.stringValue();
+
+        // Assert result
+        Assert.assertEquals("AbsoluteColorimetric", retval);
+    }
+}


### PR DESCRIPTION
Hi, 

I ran JaCoCo over the `pdfbox` module, and found a few functions that were missing unit test coverage. 

I've written some tests for these functions, with the help of [Diffblue](http://www.diffblue.com) [Cover](https://www.diffblue.com/s/Diffblue-Cover-Datasheet.pdf). 

Hopefully these tests should help you detect regressions caused by future code changes.

